### PR TITLE
PYTHON-1374: Optimized performance by removing object_pairs_hook call if we need the default conversion to dict behavior

### DIFF
--- a/bson/json_util.py
+++ b/bson/json_util.py
@@ -499,7 +499,7 @@ def loads(s: Union[str, bytes, bytearray], *args: Any, **kwargs: Any) -> Any:
     json_options = kwargs.pop("json_options", DEFAULT_JSON_OPTIONS)
     # Execution time optimization if json_options.document_class is dict
     if json_options.document_class is dict:
-        kwargs["object_hook"] = lambda pairs: object_hook(pairs, json_options)
+        kwargs["object_hook"] = lambda obj: object_hook(obj, json_options)
     else:
         kwargs["object_pairs_hook"] = lambda pairs: object_pairs_hook(pairs, json_options)
     return json.loads(s, *args, **kwargs)

--- a/bson/json_util.py
+++ b/bson/json_util.py
@@ -497,7 +497,11 @@ def loads(s: Union[str, bytes, bytearray], *args: Any, **kwargs: Any) -> Any:
        Accepts optional parameter `json_options`. See :class:`JSONOptions`.
     """
     json_options = kwargs.pop("json_options", DEFAULT_JSON_OPTIONS)
-    kwargs["object_pairs_hook"] = lambda pairs: object_pairs_hook(pairs, json_options)
+    # Execution time optimization if json_options.document_class is dict
+    if json_options.document_class is dict:
+        kwargs["object_hook"] = lambda pairs: object_hook(pairs, json_options)
+    else:
+        kwargs["object_pairs_hook"] = lambda pairs: object_pairs_hook(pairs, json_options)
     return json.loads(s, *args, **kwargs)
 
 

--- a/doc/contributors.rst
+++ b/doc/contributors.rst
@@ -99,3 +99,4 @@ The following is a list of people who have contributed to
 - Iris Ho (sleepyStick)
 - Stephan Hof (stephan-hof)
 - Casey Clements (caseyclements)
+- Ivan Lukyanchikov (ilukyanchikov)


### PR DESCRIPTION
Optimized performance by removing object_pairs_hook call if we need the default conversion to dict behavior [jira task](https://jira.mongodb.org/projects/PYTHON/issues/PYTHON-1374)
In object_hook, a dictionary is already passed, and calling object_pairs_hook for casting pairs to dict is redundant.
I validated my changes with test_json_util cases. `pytest -v -s test/test_json_util.py`
Compare performance with TestJson*Decoding cases(changes affect performance only in these cases) `pytest -v -s test/performance/perf_test.py::TestJsonFlatDecoding test/performance/perf_test.py::TestJsonDeepDecoding test/performance/perf_test.py::TestJsonFullDecoding`

| Test Name        | master | current branch        |
|------------------|------------------|--------------------|
| JsonFlatDecoding | 96.18636555725531| 117.50816018425552 |
| JsonDeepDecoding | 58.337081713027956| 77.52136671585596 |
| JsonFullDecoding | 33.81260536995342| 38.88821810950474  |

This fix only works with JSONOptions where document_class is dict, and I haven't found cases where something other than dict was used.

